### PR TITLE
Move the Rug CLI docs under Rug

### DIFF
--- a/docs/rug-cli/index.md
+++ b/docs/rug-cli/index.md
@@ -1,9 +1,0 @@
-## The Rug CLI
-
-The Rug command-line interface (CLI) provides developers with the
-tools they need to create and manage Rugs.  The links below will help
-you from get started through becoming a power user.
-
--   [Rug CLI Quick Start](/quick-starts/rug-cli.md)
--   [Rug CLI Installation](/rug-cli/rug-cli-install.md)
--   [Rug CLI Command Reference](/reference-docs/rug-cli-commands.md)

--- a/docs/rug/rug-cli-install.md
+++ b/docs/rug/rug-cli-install.md
@@ -6,6 +6,8 @@ support installing the Rug CLI on GNU/Linux Deb and RPM distributions,
 Mac OS X/macOS using [Homebrew][brew], and MS Windows
 using [Chocolatey][choco].
 
+Once you have it installed, continue with the [Rug CLI Quick Start](http://docs.atomist.com/quick-starts/rug-cli/).
+
 [brew]: http://brew.sh/
 [choco]: https://chocolatey.org/
 


### PR DESCRIPTION
This eliminates a top-level category for Rug CLI. They're nothing without each other!
I don't want people to feel like they need to learn 2 things instead of 1.