### PR TITLE
Fix name parameter for addOrReplaceDependencyScope

### DIFF
--- a/docs/reference-docs/rug/types/rug-core-types-pom.md
+++ b/docs/reference-docs/rug/types/rug-core-types-pom.md
@@ -73,7 +73,7 @@ Add or replace a dependency's scope
 | ------------|:---------------|:-------------|
 | ***groupId*** | `class java.lang.String` | *The value of the dependency's groupId* |
 | ***artifactId*** | `class java.lang.String` | *The value of the dependency's artifactId* |
-| ***newVersion*** | `class java.lang.String` | *The value of the dependency's scope to be set* |
+| ***newScope*** | `class java.lang.String` | *The value of the dependency's scope to be set* |
 
 #### Operation: `addOrReplaceDependencyVersion`
 
@@ -568,4 +568,3 @@ Return the content of the version element
 ##### Parameters
 
 *None*
-


### PR DESCRIPTION
Operation addOrReplaceDependencyScope from POM Rug Type shows `newVersion`
instead of `newScope`.