### PR TITLE
Add syntax highlighting to Rug DSL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - secure: avZof6zOvqzTz3HIWKUCCVnNtN1kUJJUulrRPqQNukYpvK6pPFmv9bv0KPZeTWr7fC88fnptjm2SbgXhtNkZxv0pqRP2Zy5yzgwZfQlHJKWb2DSA7D65kCCejHvmyIx6fbpfG4A7OMGHKP1yoUOkgm3WXmXXfckKZ0ADiEnvx1kenhF4MfMNoAxBIX/xX9NtKxWejvF/Go18ePxVW/Y+UpOQ9l8n9z3RZQ2+ocoSP/7RhQTNnJgHO+S9UtnRVN5yBkUTiLU9I7+NpvcLbBekLGyS0Vh979HT0oDU/LAbpXWIfGFm97CY7zn7pCa3vkPtbGs/+FVAo10ZYuLYYrzlxipbrEGPBAQl0eFbIu7Fl/aQWsGYM0/kLiLKFl+/8NgB+eblGb7F8CyUKWgpARlGLc50Ht0C/QBREzRT7bLoDfRxsGc90vQ+mw1D6P7w1vi6Ib3XeVw+zSKvtgb8ul+lqbuShkiH2x4gE+M/1NLByWTIsVdEqiyLK9up+xYOLw7X3swaXLTEjNVTi8havQEABn+cVZPpiOSQcIyF3ydW7kVOqAzc3ewrYPasgOTj2humYTwpAm3Cv49OqahRKA03S7iGzNCzLn1uTX6EsftztCV4OHHHZrsBNB3Kyni/OJh0hg8tc23EXPdBSy2bQFFyeHCG5oyMsy6S+aEZmC08968=
 install:
 - pip install -r requirements.txt
+- cd rug_pygments; python setup.py install; cd ..
 script:
 - mkdocs build && rm site/CNAME && bash deploy.bash $TRAVIS_REPO_SLUG && cp docs/CNAME site/CNAME
 deploy:

--- a/rug_pygments/rug.py
+++ b/rug_pygments/rug.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+
+# This module implements the pygments lexer interface to support the
+# Rug DSL (including the BDD test side).
+# To install, simply run as follows:
+#
+# $ python setup.py install
+#
+# This will automatically add this lexer to the installed pygments
+# package.
+
+from pygments.lexer import RegexLexer, bygroups, words, include
+from pygments.token import *
+
+__all__ = ['RugDSLLexer']
+__version__ = '0.1.0'
+
+
+class RugDSLLexer(RegexLexer):
+    """
+    Pygments lexer for the Rug DSL language.
+    """
+    name = 'Rug'
+    aliases = ['rug']
+    filenames = ['*.rug']
+
+    tokens = {
+        'root': [
+            (r'\n', Whitespace),
+            (r'\s+', Whitespace),
+            (r'/\*', Comment.Multiline, 'comment'),
+            (r'#.*?$', Comment.Singleline),
+            (r'"|"""|\'|\'\'\'', String, 'string'),
+            (r'(@generator)([ \t]+)(".*")$', bygroups(Name.Decorator, Text,
+                                                      String)),
+            (r'(@generator)$', Name.Decorator),
+            (r'(generator|editor|reviewer|predicate|precondition)(\s*)([A-Z][A-Za-z0-9]+)$',
+             bygroups(Keyword.Namespace, Text, Name.Namespace)),
+            (r'(scenario)(\s*)(.*)$', bygroups(Keyword.Namespace, Text,
+                                               Name.Namespace)),
+            (r'(@tag|@default)([ \t]+)(["\'].*["\'])$',
+             bygroups(Name.Decorator, Text, String)),
+            (r'(@description|@validInput|@displayName|@default)',
+             bygroups(Name.Decorator)),
+            (r'(@optional|@hide)([ \t]*)$',
+             bygroups(Name.Decorator, Text)),
+            (r'(@minLength|@maxLength)([ \t]+)([0-9]+)$',
+             bygroups(Name.Decorator, Text, Number)),
+            (r'(begin)$', Keyword.Namespace),
+            (r'(end)$', Keyword.Namespace),
+            (r'(given)$', Keyword.Namespace),
+            (r'(then)$', Keyword.Namespace),
+            (r',', Operator),
+            include('paramblock'),
+            include('letblock'),
+            include('usesblock'),
+            include('withblock'),
+            include('andblock'),
+            include('whenblock'),
+            include('doblock'),
+            include('callotherblock'),
+            include('assignblock'),
+            include('funcblock')
+        ],
+        'comment': [
+            (r'[^*/]', Comment.Multiline),
+            (r'/\*', Comment.Multiline, '#push'),
+            (r'\*/', Comment.Multiline, '#pop'),
+            (r'[*/]', Comment.Multiline)
+        ],
+        'string': [
+            ('[^"\']', String),
+            (r'"|"""|\'|\'\'\'', String, '#pop'),
+        ],
+        'jsblock': [
+            (r'[^}]', Text),
+            (r'{', Text, '#push'),
+            (r'}', Text, '#pop'),
+            (r'[}]', Text)
+        ],
+        'doblock': [
+            (r'(do)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]+)(".*")([ \t]+)([a-zA-Z_]+)',
+             bygroups(Keyword.Namespace, Text, Name.Function, Text, String,
+                      Text, Name.Variable.Instance)),
+            (r'(do)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]+)(".*")',
+             bygroups(Keyword.Namespace, Text, Name.Function, Text, String)),
+            (r'(do)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]+)([A-Za-z_]+)',
+             bygroups(Keyword.Namespace, Text, Name.Function, Text,
+                      Name.Variable.Instance)),
+            (r'(do)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]+)',
+             bygroups(Keyword.Namespace, Text, Name.Function, Text), 'jsblock'),
+            (r'(do)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]+)([A-Za-z_]+)([ \t]+)(from|to)',
+             bygroups(Keyword.Namespace, Text, Name.Function, Text,
+                      Name.Variable.Instance, Text, Operator)),
+            (r'(do)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]+)([A-Za-z_]+)([ \t]+)(from|to)',
+             bygroups(Keyword.Namespace, Text, Name.Function, Text,
+                      Name.Variable.Instance, Text, Operator)),
+            (r'(do)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]+)({)(.*)(})([ \t]+)(from|to)',
+             bygroups(Keyword.Namespace, Text, Name.Function, Text, Operator,
+                      Text, Operator, Text, Operator)),
+            (r'(do)(\s*)$',
+             bygroups(Keyword.Namespace, Text))
+        ],
+        'whenblock': [
+            (r'(when)([ \t]+)([A-Za-z_]+)([ \t]+)',
+             bygroups(Keyword.Namespace, Text, Name.Variable.Instance, Text)),
+            (r'(when)([ \t]+)([A-Za-z_]+)([ \t]+)([A-Za-z_]+)',
+             bygroups(Keyword.Namespace, Text, Name.Variable.Instance, Text,
+                      Name.Function)),
+            (r'(when)([ \t]+)([A-Za-z_]+)(.)([a-z]+)(.)([\w]+)',
+             bygroups(Keyword, Text, Name.Variable.Instance, Text,
+                      Name.Attribute, Text, Name.Function)),
+            (r'(when)([ \t]+)([A-Za-z_]+)([ \t]+)(=)([ \t]+)(".*")',
+             bygroups(Keyword.Namespace, Text, Name.Variable.Instance, Text,
+                      Operator, Text, String)),
+            (r'(when)([ \t]+)([A-Za-z_]+)(.)([a-z]+)',
+             bygroups(Keyword.Namespace, Text, Name.Variable.Instance, Text,
+                      Name.Attribute)),
+            (r'(when)([ \t]*)$',
+             bygroups(Keyword.Namespace, Text)),
+        ],
+        'withblock': [
+            (r'(with)((?:\s|\\\s)+)([a-zA-Z_.]*)([ \t]+)([a-zA-Z]+)',
+             bygroups(Keyword.Namespace, Text, Keyword.Type, Text,
+                      Name.Variable.Instance)),
+            (r'(with)((?:\s|\\\s)+)([a-zA-Z_.]*)',
+             bygroups(Keyword.Namespace, Text, Keyword.Type))
+        ],
+        'paramblock': [
+            (r'(param)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]*)(:)([ \t]*)([@a-z_]+)$',
+             bygroups(Keyword.Namespace, Text, Name.Variable, Text, Operator,
+                      Text, Name.Constant)),
+            (r'(param)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]*)(:)([ \t]*)(\^.*\$)$',
+             bygroups(Keyword.Namespace, Text, Name.Variable, Text, Operator,
+                      Text, String.Regex)),
+            (r'(param)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]*)(:)([ \t]*)(".*")$',
+             bygroups(Keyword.Namespace, Text, Name.Variable, Text, Operator,
+                      Text, String))
+        ],
+        'letblock': [
+            (r'(let)((?:\s|\\\s)+)([a-zA-Z_]+)([ \t]*)(=)([ \t]*)({)',
+             bygroups(Keyword.Namespace, Text, Name.Variable.Instance, Text,
+                      Operator, Text, Punctuation), 'jsblock'),
+            (r'(let)((?:\s|\\\s)+)([a-zA-Z_]+)([ \t]*)(=)',
+             bygroups(Keyword.Namespace, Text, Name.Variable.Instance, Text,
+                      Operator))
+        ],
+        'usesblock': [
+            (r'(uses)((?:\s|\\\s)+)([-a-z]+)(.)([-a-z]+)(.)([a-zA-Z_]+)',
+             bygroups(Keyword.Namespace, Text, Name.Namespace, Text,
+                      Name.Namespace, Text, Name.Namespace)),
+            (r'(uses)((?:\s|\\\s)+)([A-Z][A-Za-z0-9]+)',
+             bygroups(Keyword.Namespace, Text, Name.Namespace)),
+        ],
+        'andblock': [
+            (r'(and)((?:\s|\\\s)+)([A-Za-z_]+)([ \t]+)',
+             bygroups(Keyword.Namespace, Text, Name.Function, Text)),
+            (r'(and)((?:\s|\\\s)+)',
+             bygroups(Keyword.Namespace, Text), 'jsblock')
+        ],
+        'callotherblock': [
+            (r'([A-Z][A-Za-z0-9]+)([ \t]*)',
+             bygroups(Name.Namespace, Text), 'assignblock'),
+            (r'([A-Z][A-Za-z0-9]+)([ \t]*)$',
+             bygroups(Name.Namespace, Text)),
+        ],
+        'assignblock': [
+            (r'([-A-Za-z_0-9/.]+)(\s*)(=)(\s*)([A-Za-z_0-9]+)',
+             bygroups(Name.Variable, Text, Operator, Text,
+                      Name.Variable.Instance)),
+            (r'([-A-Za-z_0-9/.]+)(\s*)(=)(\s*)(".*?")',
+             bygroups(Name.Variable, Text, Operator, Text, String))
+        ],
+        'funcblock': [
+            (r'([A-Za-z_]+)([ \t]*)',
+             bygroups(Name.Function, Text)),
+        ]
+    }

--- a/rug_pygments/setup.py
+++ b/rug_pygments/setup.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from setuptools import setup
+
+from rug import __version__
+
+
+setup(
+    name='rug_pygments',
+    version=__version__,
+    py_modules=['rug'],
+    install_requires=[
+        'pygments',
+    ],
+    entry_points="""
+        [pygments.lexers]
+        rug = rug:RugDSLLexer
+    """,
+)


### PR DESCRIPTION
Add support for syntax highlighting Rug DSL in the documentation.

Closes #82.