### PR TITLE
Auto CLI ref, reorg CLI user guide

### DIFF
--- a/docs/reference/rug-cli/index.md
+++ b/docs/reference/rug-cli/index.md
@@ -1,161 +1,396 @@
-This page documents syntax and functionality of the Rug CLI.
+Below is the complete list of options and commands for the Rug CLI.
 
-!!! note ""
-    All commands listed below are provided only as examples of the
-    syntax.  They may refer to Rugs and Rug archives or projects that
-    do not exist and therefore may not work.
+## Global command-line options
 
-## Configuring
+`-?`, `--help`
+:   Print help information
 
-In order to use the CLI the following file named `cli.yml` needs to be
-placed in `~/.atomist`.  The contents of the simplest possible
-`cli.yml` are below.
+`-h`, `--help`
+:   Print help information
 
-```yaml
-# Set up the path to the local repository
-local-repository:
-  path: "${user.home}/.atomist/repository"
+`-o`, `--offline`
+:   Use only downloaded archives
 
-# Set up remote repositories to query for Rug archives. Additionally one of the
-# repositories can also be enabled for publication (publish: true).
-remote-repositories:
-  maven-central:
-    publish: false
-    url: "http://repo.maven.apache.org/maven2/"
-  rug-types:
-    publish: false
-    url: "https://atomist.jfrog.io/atomist/libs-release"
-  rugs:
-    publish: false
-    url: "https://atomist.jfrog.io/atomist/rugs-release"
-```
+`-q`, `--quiet`
+:   Do not display progress messages
 
-The Rug CLI will create the above `cli.yml` if you do not already have
-one.
+`--requires=RUG_VERSION`
+:   Overwrite the Rug version to RUG_VERSION (Use with Caution)
+
+`-r`, `--resolver-report`
+:   Print dependency tree
+
+`-s FILE`, `--settings=FILE`
+:   Use settings file FILE
+
+`-t`, `--timer`
+:   Print timing information
+
+`-u`, `--update`
+:   Update dependency resolution
+
+`-V`, `--verbose`
+:   Print verbose output
+
+`-X`, `--error`
+:   Print stacktraces
 
 ## Commands
 
-The CLI will assume the current working directory to be the root for execution.
+### `default`
 
-### Using the CLI as Rug users
+Set default archive
 
-#### Invoking Editors
-
-Run an editor as follows:
+*Usage:*
 
 ```console
-$ rug edit atomist-rugs:common-editors:AddReadme --artifact-version 1.0.0 \
-    parameter1=foo parameter2=bar
-
-$ rug edit atomist-rugs:common-editors:AddReadme parameter1=foo parameter2=bar
+$ rug default [OPTION]... ACTION [ARCHIVE]
 ```
 
-`artifact-version` is optional and defaults to `latest` semantics.
-`--change-dir` or `-C` for giving a generator a target directory.
+ACTION should be save or delete.  ARCHIVE should be a valid archive identifier of form GROUP:ARTIFACT or just GROUP.  At any time those defaults can be overriden by specifying GROUP:ARTIFACT and -a from the command line.
 
-#### Invoking Generators
+*Subcommands:* `save`, `delete`
+
+*Command options:*
+
+`-a AV`, `--archive-version=AV`
+:   Set default archive version to AV
+
+`-g`, `--global`
+:   Set global or project default archive
+
+### `describe`
+
+Print details about an archive or Rug
+
+*Usage:*
 
 ```console
-$ rug generate atomist-rugs:spring-boot-rest-service:NewSpringBootRestService" \
-    --artifact-version 1.0.0 my-new-project parameter1=foo parameter2=bar
-
-$ rug generate atomist-rugs:spring-boot-rest-service:NewSpringBootRestService" \
-    my-new-project parameter1=foo parameter2=bar
+$ rug describe [OPTION]... TYPE ARTIFACT
 ```
 
-`artifact-version` is optional and defaults to `latest` semantics.
-`--change-dir` or `-C` for giving a generator a target directory.
+TYPE should be 'editor', 'generator', 'reviewer', 'command-handler', 'event-handler', 'response-handler' or 'archive' and ARTIFACT should be the full name of an artifact, e.g., "atomist:spring-service:Spring Microservice".  If the name of the artifact has spaces in it, you need to put quotes around it.  FORMAT can be 'json' or 'yaml' and is only valid when describing an archive.
 
-#### Describing Rug Artifacts
+*Command aliases:* `desc`
 
-To get information about a Rug and list all its parameters, run the
-`rug describe` command.
+*Subcommands:* `editor`, `generator`, `reviewer`, `archive`, `command-handler`, `event-handler`, `response-handler`
+
+*Command options:*
+
+`-a AV`, `--archive-version=AV`
+:   Use archive version AV
+
+`-l`, `--local`
+:   Use local working directory as archive
+
+`-O FORMAT`, `--output=FORMAT`
+:   Specify output FORMAT
+
+### `edit`
+
+Run an editor to modify an existing project
+
+*Usage:*
 
 ```console
-$ rug describe archive atomist-rugs:spring-rest-service
-
-$ rug describe editor atomist-rugs:spring-boot-rest-service:SpringBootThing \
-    --artifact-version 1.0.0
-
-$ rug describe generator atomist-rugs:spring-boot-rest-service:NewSpringBootThing \
-    --artifact-version 1.0.0
+$ rug edit [OPTION]... EDITOR [PARAMETER]...
 ```
 
-#### Listing Local Archives
+EDITOR is a Rug editor, e.g., "atomist:common-editors:AddReadme".  If the name of the editor has spaces in it, you need to put quotes around it.  To pass parameters to the editor you can specify multiple PARAMETERs in "form NAME=VALUE".
 
-To list all locally available Rug archives, run the `rug list`
-command:
+*Command aliases:* `ed`
+
+*Command options:*
+
+`-a AV`, `--archive-version=AV`
+:   Use archive version AV
+
+`-C DIR`, `--change-dir=DIR`
+:   Run editor in directory DIR, default is '.'
+
+`-d`, `--dry-run`
+:   Do not persist changes, print diffs
+
+`-I`, `--interactive`
+:   Interactive mode for specifying parameter values
+
+`-l`, `--local`
+:   Use local working directory as archive
+
+`-R`, `--repo`
+:   Commit files to local git repository
+
+### `exit`
+
+Exit a shell session
+
+*Usage:*
 
 ```console
-$ rug list -f 'version=[1.2,2.0)' -f 'group=*atomist*' -f 'artifact=*sp?ing*'
+$ rug exit [OPTION]...
 ```
 
-The local listing can be filtered by using `-f` filter expressions on
-`group`, `artifact` and `version`. `group` and `artifact` support
-wildcards of `*` and `?`.  `version` takes any version constraint.
+*Command aliases:* `quit`, `q`
 
-### Using the CLI as Rug developer
+### `extension`
 
-All the following commands need to executed from within the Rug
-project directory.
+Manage command line extensions
 
-#### Running Tests
-
-To run all tests:
+*Usage:*
 
 ```console
-$ rug test
+$ rug extension SUBCOMMAND [OPTION]... [EXTENSION]
 ```
 
-To run a specific named test:
+SUBCOMMAND is either install, uninstall or list.  EXTENSION should be a valid extension identifier of form GROUP:ARTIFACT.  If no version EV is provided with -a, the latest version of the extension is installed.
+
+*Command aliases:* `ext`
+
+*Subcommands:* `list`, `install`, `uninstall`
+
+*Command options:*
+
+`-a EV`, `--extension-version=EV`
+:   Version EV of extension to install
+
+### `generate`
+
+Run a generator to create a new project
+
+*Usage:*
 
 ```console
-$ rug test "Whatever Test Secanrio"
+$ rug generate [OPTION]... GENERATOR PROJECT_NAME [PARAMETER]...
 ```
 
-To run all scenarios from a .rt file:
+GENERATOR is a Rug generator, e.g., "atomist:spring-service:Spring Microservice".  If the name of the generator has spaces in it, you need to put quotes around it.  PROJECT_NAME specifies the required name of the generated project.  To pass parameters to the generator you can specify multiple PARAMETERs in form "NAME=VALUE".
+
+*Command aliases:* `gen`
+
+*Command options:*
+
+`-a AV`, `--archive-version=AV`
+:   Use archive version AV
+
+`-C DIR`, `--change-dir=DIR`
+:   Create project in directory DIR, default is '.'
+
+`-F`, `--overwrite`
+:   Force overwrite if target directory already exists
+
+`-I`, `--interactive`
+:   Interactive mode for specifying parameter values
+
+`-l`, `--local`
+:   Use local working directory as archive
+
+`-R`, `--repo`
+:   Initialize and commit files to a new git repository
+
+### `help`
+
+Print usage help
+
+*Usage:*
 
 ```console
-$ rug test MyRugTestFilename
+$ rug help
 ```
 
-#### Installing a Rug archive
+Prints this usage help.
 
-Creating a Rug zip archive and installing it into the local repository
-can be done with the following command:
+*Command aliases:* `h`, `?`
+
+### `install`
+
+Create and install an archive into the local repository
+
+*Usage:*
 
 ```console
-$ rug install
+$ rug install [OPTION]...
 ```
 
-This command packages the project into a zip archive, creates a Pom
-and installs both into the local repository under, usually
-`.atomist/repository`.
+Create and install an archive from the current project in the local repository.  Ensure that there is a manifest.yml descriptor in the .atomist directory.
 
-## Dependency Resolution
+*Command options:*
 
-The Rug CLI will automatically resolve and download the dependencies
-of the given Rug archive when `edit` or `generate` is invoked. The
-archives along with their dependencies will be downloaded to a local
-repository under `~/.atomist` via Aether and resolved from there.
+`-a AV`, `--archive-version=AV`
+:   Override archive version with AV
 
-Therefore running above commands is a two step process:
+### `list`
 
-1.  Search and resolve (eventually download) the archive referenced in
-    the command.  The result of a resolution is cached for 60
-    minutes. You can force re-resolution with the `-r` command-line
-    option.
-2.  Start up `rug-lib` passing parameters over to run the editor or
-    generator
+List locally installed archives
 
-## Advanced Topics
-
-### Turning on Verbose output for Debugging
-
-If you want a more verbose output that includes any exceptions that
-Rug command may have encountered, please add `-X` to your command.
-For example:
+*Usage:*
 
 ```console
-$ rug test -X
+$ rug list [OPTION]...
 ```
+
+FILTER could be any of group, artifact or version.  VALUE should be a valid filter expression: for group and artifact ? and * are supported as wildcards;  the version filter can be any valid version or version range.
+
+*Command aliases:* `ls`
+
+*Command options:*
+
+`-f FILTER=VALUE`, `--filter=FILTER=VALUE`
+:   Specify filter of type FILTER with VALUE
+
+### `path`
+
+Evaluate a path expression against a project
+
+*Usage:*
+
+```console
+$ rug path [OPTION]... [EXPRESSION]
+```
+
+EXPRESSION can be any valid Rug path expression.  Depending on your expression you might need to put it in quotes.  Use '--values' to display values of tree nodes; caution as this option might lead to a lot of data being printed.
+
+*Command aliases:* `tree`
+
+*Command options:*
+
+`-C DIR`, `--change-dir=DIR`
+:   Evaluate expression against project in directory DIR, default is '.'
+
+`-v`, `--values`
+:   Displays tree node values
+
+### `publish`
+
+Create and publish an archive into a remote repository
+
+*Usage:*
+
+```console
+$ rug publish [OPTION]...
+```
+
+Create a Rug archive from the current repo and publish it in a remote repository.  Ensure that there is a manifest.yml descriptor in the .atomist directory.  Use -i to specify what repository configuration should be used to publish.  ID should refer to a repository name in cli.yml
+
+*Command options:*
+
+`--archive-artifact=AA`
+:   Override archive artifact with AA
+
+`--archive-group=AG`
+:   Override archive group with AG
+
+`-a AV`, `--archive-version=AV`
+:   Override archive version with AV
+
+`-i ID`, `--id=ID`
+:   ID identifying the repository to publish into
+
+### `repositories`
+
+Login and configure team-scoped repositories
+
+*Usage:*
+
+```console
+$ rug repositories SUBCOMMAND [OPTION]...
+```
+
+The Rug CLI uses your GitHub token to verify your membership in GitHub organizations and Slack teams that have the Atomist Bot enrolled.  Those teams have acccess to additional features, eg. team private Rug archives.  You can use the 'login' subcommand to login and then 'configure' to provision the list of repositories you have access to.
+
+*Command aliases:* `repo`
+
+*Subcommands:* `login`, `configure`
+
+*Command options:*
+
+`--mfa-code=MFA_CODE`
+:   GitHub MFA code (only required if MFA is enabled)
+
+`--username=USERNAME`
+:   GitHub username
+
+### `search`
+
+Search online catalog of available archives
+
+*Usage:*
+
+```console
+$ rug search [OPTION]... [SEARCH]
+```
+
+SEARCH could be any text used to search the catalog.  TAG can be any valid tag, eg. spring or elm.  TYPE can be either 'editor', 'generator', 'executor' or 'reviewer'.
+
+*Command options:*
+
+`--operations`
+:   Show operations in search output
+
+`-T TAG`, `--tag=TAG`
+:   Specify a TAG to filter search
+
+`--type=TYPE`
+:   Specify a TYPE to filter search based on Rug type
+
+### `shell`
+
+Start a shell for the specified Rug archive
+
+*Usage:*
+
+```console
+$ rug shell [OPTION]... ARCHIVE
+```
+
+ARCHIVE should be a full name of an Rug archive, e.g., "atomist:spring-service".
+
+*Command aliases:* `repl`, `load`
+
+*Command options:*
+
+`-a AV`, `--archive-version=AV`
+:   Use archive version AV
+
+`-l`, `--local`
+:   Use local working directory as archive
+
+### `test`
+
+Run test scenarios
+
+*Usage:*
+
+```console
+$ rug test [OPTION]... [TEST]
+```
+
+TEST is the name of a test scenario.  If no TEST is specified, all scenarios will run.
+
+### `to-path`
+
+Display path expression to a point in a file within a project
+
+*Usage:*
+
+```console
+$ rug to-path [OPTION]... PATH
+```
+
+PATH must be a valid path within the project at DIR or '.'.  
+
+*Command aliases:* `to-tree`
+
+*Command options:*
+
+`-C DIR`, `--change-dir=DIR`
+:   Evaluate expression against project in directory DIR, default is '.'
+
+`--column=COLUMN`
+:   Column within file at LINE
+
+`--kind=KIND`
+:   Rug Extension kind, eg. 'ScalaFile' or 'Pom'
+
+`--line=LINE`
+:   Line within the file
+

--- a/docs/user-guide/interfaces/cli/basics.md
+++ b/docs/user-guide/interfaces/cli/basics.md
@@ -22,15 +22,12 @@ local-repository:
 # Set up remote repositories to query for Rug archives. Additionally one of the
 # repositories can also be enabled for publication (publish: true).
 remote-repositories:
-  maven-central:
+  central:
     publish: false
     url: "http://repo.maven.apache.org/maven2/"
-  rug-types:
-    publish: false
-    url: "https://atomist.jfrog.io/atomist/libs-release"
   rugs:
     publish: false
-    url: "https://atomist.jfrog.io/atomist/rugs-release"
+    url: "https://atomist.jfrog.io/atomist/rugs"
 ```
 
 You can configure a repository directory on your local file system
@@ -50,9 +47,9 @@ a repository would look something like:
 
 ```yaml
 remote-repositories:
-  rugs:
-    url: "https://atomist.jfrog.io/atomist/rugs-release"
+  rugs-release:
     publish: true
+    url: "https://atomist.jfrog.io/atomist/rugs-release"
     authentication:
       username: "YOUR_USER_NAME"
       password: "YOUR_PASSWORD_OR_TOKEN"
@@ -151,8 +148,8 @@ output.  The second line contains detailed information from Git.
 
 ```console
 $ rug --version
-rug 0.24.0
-https://github.com/atomist/rug-cli.git (git revision f88e69c; last commit 2017-02-20)
+rug 0.25.0
+https://github.com/atomist/rug-cli.git (git revision a7aab63; last commit 2017-03-10)
 ```
 
 ## Debugging

--- a/docs/user-guide/interfaces/cli/basics.md
+++ b/docs/user-guide/interfaces/cli/basics.md
@@ -1,0 +1,88 @@
+Before we get to using the CLI, let's cover some information on
+configuration and behavior.
+
+## Configuring
+
+The default Rug CLI configuration file is located at
+`~/.atomist/cli.yml`.  You can override the default location using the
+`--settings=PATH` command-line option.  As the configuration file
+extension suggests, it is a [YAML][yaml] file.
+
+[yaml]: http://yaml.org/
+
+If you are using the default configuration file and one does not
+exist, the CLI will create a default one for you with contents like
+the following.
+
+```yaml
+# Set up the path to the local repository
+local-repository:
+  path: "${user.home}/.atomist/repository"
+
+# Set up remote repositories to query for Rug archives. Additionally one of the
+# repositories can also be enabled for publication (publish: true).
+remote-repositories:
+  maven-central:
+    publish: false
+    url: "http://repo.maven.apache.org/maven2/"
+  rug-types:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/libs-release"
+  rugs:
+    publish: false
+    url: "https://atomist.jfrog.io/atomist/rugs-release"
+
+# Set up Rug catalog endpoints for searching
+catalogs:
+- "https://api.atomist.com/catalog"
+```
+
+You can configure a repository directory on your local file system
+using the `path` key under the `local-repository` key.  When
+specifying your system home directory, use the portable `${user.home}`
+rather than system-specific `$HOME` or `~`.
+
+You can specify any number of remote repositories under the
+`remote-repositories` key.  The value of the key should be a mapping
+whose keys are unique identifiers for each entry and whose values
+provide the `url` and optionally whether to `publish` rugs to the
+repository.  If you are publishing Rugs to the repository, you will
+likely need to supply `authentication` details for the repository.
+The authentication details should be a mapping specifying the
+`username` and `password`.  A complete configuration for publishing to
+a repository would look something like:
+
+```yaml
+remote-repositories:
+  rugs:
+    url: "https://atomist.jfrog.io/atomist/rugs-release"
+    publish: true
+    authentication:
+      username: "YOUR_USER_NAME"
+      password: "YOUR_PASSWORD_OR_TOKEN"
+```
+
+You can specify any number of Rug catalogs to search using the
+`catalogs` key.  The value of the key should be a sequence where each
+element is a URL to a Rug catalog.
+
+## Dependency Resolution
+
+The Rug CLI will automatically resolve and download all dependencies
+it needs to perform the requested operation.  Dependencies
+include [JAR][jar] files and Rug archives.  Dependencies will be
+downloaded to the configured local repository, `~/.atomist/repository`
+by default, via [Aether][aether] and resolved from there.
+
+[jar]: https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jarGuide.html
+[aether]: https://eclipse.org/aether/
+
+## Debugging
+
+If you want a more verbose output that includes any exceptions that
+Rug command may have encountered, please add `-X` to your command.
+For example:
+
+```console
+$ rug test -X
+```

--- a/docs/user-guide/interfaces/cli/basics.md
+++ b/docs/user-guide/interfaces/cli/basics.md
@@ -31,10 +31,6 @@ remote-repositories:
   rugs:
     publish: false
     url: "https://atomist.jfrog.io/atomist/rugs-release"
-
-# Set up Rug catalog endpoints for searching
-catalogs:
-- "https://api.atomist.com/catalog"
 ```
 
 You can configure a repository directory on your local file system
@@ -62,10 +58,6 @@ remote-repositories:
       password: "YOUR_PASSWORD_OR_TOKEN"
 ```
 
-You can specify any number of Rug catalogs to search using the
-`catalogs` key.  The value of the key should be a sequence where each
-element is a URL to a Rug catalog.
-
 ## Dependency Resolution
 
 The Rug CLI will automatically resolve and download all dependencies
@@ -76,6 +68,92 @@ by default, via [Aether][aether] and resolved from there.
 
 [jar]: https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jarGuide.html
 [aether]: https://eclipse.org/aether/
+
+## Help
+
+The Rug CLI provides standard help output when the `--help`, `-h`, or
+`-?` command-line option is used.  All of these options provide the
+same output in the same context.  You can use the help command-line
+option on the `rug` command itself to receive general information
+about the Rug CLI, its options, and its subcommands.
+
+```console
+$ rug --help
+Usage: rug [OPTION]... [COMMAND]...
+Work with Rugs like editors or generators.
+
+Options:
+  -?,-h,--help  Print help information
+  -q,--quiet    Do not display progress messages
+  -v,--version  Print version information
+
+Available commands:
+  search        Search online catalog of available archives
+  list          List locally installed archives
+  describe      Print details about an archive or Rug
+
+  generate      Run a generator to create a new project
+  edit          Run an editor to modify an existing project
+  test          Run test scenarios
+  install       Create and install an archive into the local repository
+  publish       Create and publish an archive into a remote repository
+
+  tree          Evaluate a tree expression against a project
+
+  repositories  Login and configure team-scoped repositories
+  default       Set default archive
+  extension     Manage command line extensions
+
+  shell         Start a shell for the specified Rug archive
+  help          Print usage help
+
+Run 'rug COMMAND --help' for more detailed information on COMMAND.
+
+Please report issues at https://github.com/atomist/rug-cli
+```
+
+You can get help on any subcommand by supplying the help command-line
+option after the subcommand.
+
+```console
+$ rug search --help
+Usage: rug search [OPTION]... [SEARCH]
+Search online catalog of available archives.
+
+Options:
+  -X,--error            Print stacktraces
+  -?,-h,--help          Print help information
+  -o,--offline          Use only downloaded archives
+  -q,--quiet            Do not display progress messages
+  -r,--resolver-report  Print dependency tree
+  -s,--settings FILE    Use settings file FILE
+  -t,--timer            Print timing information
+  -u,--update           Update dependency resolution
+  -V,--verbose          Print verbose output
+
+Command Options:
+  --operations     Show operations in search output
+  -T,--tag TAG     Specify a TAG to filter search
+  --type TYPE      Specify a TYPE to filter search based on Rug type
+
+SEARCH could be any text used to search the catalog.  TAG can be any valid tag,
+eg. spring or elm.  TYPE can be either 'editor', 'generator', 'executor' or
+'reviewer'.
+
+Please report issues at https://github.com/atomist/rug-cli
+```
+
+## Version
+
+The Rug CLI supports the standard `--version` command-line option.  It
+will print the canonical version information on the first line of
+output.  The second line contains detailed information from Git.
+
+```console
+$ rug --version
+rug 0.24.0
+https://github.com/atomist/rug-cli.git (git revision f88e69c; last commit 2017-02-20)
+```
 
 ## Debugging
 

--- a/docs/user-guide/interfaces/cli/developing-rugs.md
+++ b/docs/user-guide/interfaces/cli/developing-rugs.md
@@ -172,7 +172,7 @@ To run a specific named test:
 $ rug test "Whatever Test Secanrio"
 ```
 
-To run all scenarios from a .rt file:
+To run all scenarios from a single test file:
 
 ```console
 $ rug test MyRugTestFilename
@@ -202,57 +202,7 @@ Installing archive into local repository completed
 
 → Contents
   ├─┬ .atomist
-  | ├─┬ build
-  | | ├── cli-build.yml
-  | | ├── cli-dev.yml
-  | | └── cli-release.yml
-  | ├─┬ editors
-  | | ├── AddApacheSoftwareLicense20.rug
-  | | ├── AddChangeLog.rug
-  | | ├── AddReadme.rug
-  | | ├── AddScalaMavenGitIgnore.rug
-  | | ├── ClassRenamer.rug
-  | | ├── PackageMove.rug
-  | | ├── PomParameterizer.rug
-  | | ├── RemoveApacheSoftwareLicense20.rug
-  | | ├── RemoveChangeLog.rug
-  | | └── RemoveCodeOfConduct.rug
-  | ├── manifest.yml
-  | ├── metadata.json
-  | ├─┬ templates
-  | | ├── ApacheSoftwareLicenseV20.vm
-  | | ├── CHANGELOG.md.mustache
-  | | ├── gitignore.vm
-  | | └── readme.vm
-  | └─┬ tests
-  |   ├── AddApacheSoftwareLicense20.rt
-  |   ├── AddChangeLog.rt
-  |   ├── AddGitIgnore.rt
-  |   ├── AddReadme.rt
-  |   ├── ClassRenamer.rt
-  |   ├── PackageMove.rt
-  |   ├── PomParameterizer.rt
-  |   ├── RemoveApacheSoftwareLicense20.rt
-  |   ├── RemoveChangeLog.rt
-  |   └── RemoveCodeOfConduct.rt
-  ├── .atomist.yml
-  ├── .gitignore
-  ├── CHANGELOG.md
-  ├── CODE_OF_CONDUCT.md
-  ├── LICENSE
-  ├─┬ META-INF/maven/atomist-rugs/common-editors
-  | └── pom.xml
-  ├── README.md
-  ├─┬ src/main/java/com/atomist/springrest
-  | ├── SpringRestApplication.java
-  | └── SpringRestConfiguration.java
-  ├─┬ src/main/resources
-  | ├── application.properties
-  | └── logback.xml
-  └─┬ src/test/java/com/atomist/springrest
-    ├── SpringRestApplicationTests.java
-    ├── SpringRestOutOfContainerIntegrationTests.java
-    └── SpringRestWebIntegrationTests.java
+...
 
 Successfully installed archive for atomist-rugs:common-editors:0.7.0
 ```

--- a/docs/user-guide/interfaces/cli/developing-rugs.md
+++ b/docs/user-guide/interfaces/cli/developing-rugs.md
@@ -1,21 +1,15 @@
-The Rug CLI gives you the tooling to search, install, and run public
-and private Rugs on your local machine. It is also the tool to
-develop, test and publish your own Rugs.
-
-## Installing the Rug CLI
-
-You can install the Rug command-line interface using standard
-packaging tools for your operating system.
-See [Rug CLI Installation](install.md) for instructions.
+The Rug CLI gives you the tooling to develop, test, and publish your
+own Rugs.
 
 ## Additional Dependencies
 
-Rugs are implemented in [TypeScript][ts] and it is recommended you install
-[npm][npm]. You should also get an IDE that has good support for that
-language.
+Rugs are implemented in [TypeScript][ts] and it is recommended you
+install [npm][npm].  You should also get an [IDE/editor][editor] with
+good support for TypeScript language.
 
 [ts]: https://www.typescriptlang.org/
 [npm]: https://docs.npmjs.com/getting-started/installing-node
+[editor]: https://github.com/Microsoft/TypeScript/wiki/TypeScript-Editor-Support
 
 ## Quick CLI Tour
 
@@ -171,6 +165,18 @@ be faster.
 
 As you can see from the last line of output, all of the test scenarios
 passed.
+
+To run a specific named test:
+
+```console
+$ rug test "Whatever Test Secanrio"
+```
+
+To run all scenarios from a .rt file:
+
+```console
+$ rug test MyRugTestFilename
+```
 
 ### Make your Rugs Available
 

--- a/docs/user-guide/interfaces/cli/index.md
+++ b/docs/user-guide/interfaces/cli/index.md
@@ -3,11 +3,12 @@ to execute Rugs in their command terminal and to script the execution
 of Rug using the shell.  The CLI provides developers with the tools
 they need to create, test, and manage Rugs.
 
-!!! note
+!!! note ""
     If you only plan on benefiting from Atomist capabilities through
     its standard integrations in chat, you do not need the CLI.
 
--   [Rug CLI Installation](install.md)
+-   [Rug CLI installation](install.md)
+-   [Rug Configuration and options](basics.md)
 -   [Using the CLI to execute Rugs](using-rugs.md)
 -   [Developing Rugs with the Rug CLI](developing-rugs.md)
--   [Rug CLI Command Reference](/reference/rug-cli/index.md)
+-   [Rug CLI command reference](/reference/rug-cli/index.md)

--- a/docs/user-guide/interfaces/cli/using-rugs.md
+++ b/docs/user-guide/interfaces/cli/using-rugs.md
@@ -126,21 +126,7 @@ Loading atomist-rugs:rug-editors:0.14.0 into runtime completed
   → description *: an editor created interactively
 
 Running editor AddTypeScriptEditor of atomist-rugs:rug-editors:0.14.0 completed
-
-→ Project
-  ~/develop/atomist-rugs/rug-editors/ (1 mb in 476 files)
-
-→ Changes
-  ├── .atomist/editors/MyNewEditor.ts created (898 bytes)
-  ├── .atomist/tests/MyNewEditor.rt created (213 bytes)
-  ├── .atomist/editors/MyNewEditor.ts updated (877 bytes)
-  ├── .atomist/editors/MyNewEditor.ts updated (862 bytes)
-  ├── .atomist/editors/MyNewEditor.ts updated (857 bytes)
-  ├── .atomist/tests/MyNewEditor.rt updated (198 bytes)
-  ├── README.md updated (12 kb)
-  └── .atomist.yml created (5 kb)
-
-Successfully edited project rug-editors
+...
 ```
 
 ## Generators

--- a/docs/user-guide/interfaces/cli/using-rugs.md
+++ b/docs/user-guide/interfaces/cli/using-rugs.md
@@ -15,7 +15,7 @@ file system.
 To find available generators with the CLI, run the following command.
 
 ```console
-$ rug search --operations --type generator
+$ rug search --operations --type=generator
 Resolving version range for com.atomist:rug:(0.12.9,0.13.1) completed
 Resolving dependencies for com.atomist:rug:0.13.0-SNAPSHOT completed
   Searching https://api.atomist.com/catalog/operation/search
@@ -38,7 +38,27 @@ Searching catalogs completed
 When you use the `--operations` command-line argument, the output
 lists the name of the Rug and its Rug archive.  Providing the `--type
 RUG_TYPE` command-line option limits the results to Rugs of that type,
-e.g., `generator` or `editor`.
+e.g., `generator` or `editor`.  The `-T` or `--tag` command-line
+option can be provided to limit the search results to only those Rugs
+that have the provided tag.  You can supply the tag command-line
+option multiple times.
+
+```console
+$ rug search --operations --tag=rug --tag=typescript
+Resolving dependencies for atomist-rugs:rug-editors:0.15.0 ← local completed
+  Searching https://api.atomist.com/catalog
+Searching catalogs completed
+
+→ Remote Archives (1 archive found)
+  atomist-rugs:rug-editors [public] (0.14.0)
+    Editors
+    ├── AddTypeScript
+    ├── AddTypeScriptEditor
+    └── AddTypeScriptGenerator
+
+For more information on specific archive version, run:
+  rug describe archive ARCHIVE -a VERSION
+```
 
 ## Describe
 
@@ -85,6 +105,44 @@ Providing `--artifact-version` is optional and defaults to `latest`
 semantics.  `--change-dir` or `-C` to tell the CLI to apply the editor
 to a directory other than the current working directory.
 
+You can also run editors in *interactive mode* using the `-I` or
+`--interactive` command-line option.  In this mode, the CLI will
+prompt you to supply values for each editor parameter.  If you supply
+a value for a parameter on the command line in this mode, the CLI will
+use that value as the default when prompting.
+
+```console
+$ rug edit --interactive atomist-rugs:rug-editors:AddTypeScriptEditor editor_name=MyNewEditor
+Resolving dependencies for atomist-rugs:rug-editors:latest completed
+Loading atomist-rugs:rug-editors:0.14.0 into runtime completed
+
+→ Please specify parameter values
+  Press 'Enter' to accept default or provided values. '*' indicates required parameters.
+
+  name of new editor to add to Rug archive project
+  → editor_name [MyNewEditor]*:
+
+  short description of editor to add to Rug archive project
+  → description *: an editor created interactively
+
+Running editor AddTypeScriptEditor of atomist-rugs:rug-editors:0.14.0 completed
+
+→ Project
+  ~/develop/atomist-rugs/rug-editors/ (1 mb in 476 files)
+
+→ Changes
+  ├── .atomist/editors/MyNewEditor.ts created (898 bytes)
+  ├── .atomist/tests/MyNewEditor.rt created (213 bytes)
+  ├── .atomist/editors/MyNewEditor.ts updated (877 bytes)
+  ├── .atomist/editors/MyNewEditor.ts updated (862 bytes)
+  ├── .atomist/editors/MyNewEditor.ts updated (857 bytes)
+  ├── .atomist/tests/MyNewEditor.rt updated (198 bytes)
+  ├── README.md updated (12 kb)
+  └── .atomist.yml created (5 kb)
+
+Successfully edited project rug-editors
+```
+
 ## Generators
 
 You can create new projects on your local machine using the CLI, for instance:
@@ -110,3 +168,7 @@ Providing `--artifact-version` is optional and defaults to `latest`
 semantics.  `--change-dir` or `-C` to tell the CLI to create the
 project under a directory different than the current working
 directory.
+
+Like editors, you can also run generators in interactive mode and the
+CLI will prompt you for each parameter value rather than having to set
+it on the command line.

--- a/docs/user-guide/interfaces/cli/using-rugs.md
+++ b/docs/user-guide/interfaces/cli/using-rugs.md
@@ -1,6 +1,15 @@
 The Rug CLI is able to run Rugs locally against projects on your local
 file system.
 
+!!! caution ""
+    The command-line example below are intended to illuminate the use
+    of the Rug CLI.  The Rugs referenced and sample output do not
+    necessarily reflect the current reality.
+
+!!! tip ""
+    The `rug CLI` downloads the Rugs and dependencies it needs on the
+    fly. There is no specific `download` command.
+
 ## Search
 
 To find available generators with the CLI, run the following command.
@@ -26,20 +35,78 @@ Searching catalogs completed
 ...
 ```
 
-The output informs you about the name of the Rug generator and which
-Rug archive it lives in.
+When you use the `--operations` command-line argument, the output
+lists the name of the Rug and its Rug archive.  Providing the `--type
+RUG_TYPE` command-line option limits the results to Rugs of that type,
+e.g., `generator` or `editor`.
+
+## Describe
+
+To get information about a Rug and list all its parameters, run the
+`rug describe` command.
+
+```console
+$ rug describe archive atomist-rugs:spring-rest-service
+
+$ rug describe editor atomist-rugs:spring-boot-rest-service:SpringBootThing \
+    --artifact-version=1.0.0
+
+$ rug describe generator atomist-rugs:spring-boot-rest-service:NewSpringBootThing
+```
+
+Providing `--artifact-version` is optional and defaults to `latest`
+semantics.
+
+## List
+
+To list all locally available Rug archives, run the `rug list`
+command:
+
+```console
+$ rug list -f 'version=[1.2,2.0)' -f 'group=*atomist*' -f 'artifact=*sp?ing*'
+```
+
+The local listing can be filtered by using `-f` filter expressions on
+`group`, `artifact` and `version`. `group` and `artifact` support
+wildcards of `*` and `?`.  `version` takes any version constraint.
+
+## Edit
+
+Run an editor as follows:
+
+```console
+$ rug edit atomist-rugs:common-editors:AddReadme --artifact-version=1.0.0 \
+    parameter1=foo parameter2=bar
+
+$ rug edit atomist-rugs:common-editors:AddReadme parameter1=foo parameter2=bar
+```
+
+Providing `--artifact-version` is optional and defaults to `latest`
+semantics.  `--change-dir` or `-C` to tell the CLI to apply the editor
+to a directory other than the current working directory.
 
 ## Generators
 
 You can create new projects on your local machine using the CLI, for instance:
 
-```
+```console
 $ cd ~/workspace
 $ rug generate atomist-rugs:rug-project:NewStarterRugProject my-new-generator
 ```
 
-The first argument is always the project name.
+The first argument is always the project name.  If the generator
+requires additional parameters, just append the `parameter=value` to
+the end of the command line.
 
-!!! tip
-    Whenever you run a Rug Generator, the `rug CLI` downloads the archive on the
-    fly before applying it. There is no specific `download` command.
+```console
+$ rug generate atomist-rugs:spring-boot-rest-service:NewSpringBootRestService" \
+    --artifact-version=1.0.0 my-new-project parameter1=foo parameter2=bar
+
+$ rug generate atomist-rugs:spring-boot-rest-service:NewSpringBootRestService" \
+    my-new-project parameter1=foo parameter2=bar
+```
+
+Providing `--artifact-version` is optional and defaults to `latest`
+semantics.  `--change-dir` or `-C` to tell the CLI to create the
+project under a directory different than the current working
+directory.

--- a/docs/user-guide/rug/generators.md
+++ b/docs/user-guide/rug/generators.md
@@ -42,7 +42,7 @@ mkdocs-project
     │   ├── editors
     │   │   └── NewMkDocsDocumentationProject.ts
     │   └── tests
-    │       └── NewMkDocsDocumentationProject.rt
+    │       └── NewMkDocsDocumentationProjectTest.ts
     ├── README.md
     ├── docs
     │   └── index.md

--- a/docs/user-guide/rug/lifecycle.md
+++ b/docs/user-guide/rug/lifecycle.md
@@ -38,7 +38,7 @@ Running generator NewRugArchiveProject of atomist-rugs:rug-archive:0.2.1 complet
   | ├─┬ templates
   | | └── readme.vm
   | └─┬ tests
-  |   └── AddReadme.rt
+  |   └── AddReadmeTest.ts
   ├── .atomist.yml
   ├── .gitignore
   └── README.md
@@ -63,7 +63,7 @@ my-rug-project
 │   ├── templates
 │   │   └── readme.vm
 │   └── tests
-│       └── AddReadme.rt
+│       └── AddReadmeTest.ts
 ├── .atomist.yml
 ├── .gitignore
 └── README.md
@@ -71,7 +71,7 @@ my-rug-project
 4 directories, 7 files
 ```
 
-The editor `AddReadme.rug` and corresponding test `AddReadme.rt` have
+The editor `AddReadme.rug` and corresponding test `AddReadmeTest.ts` have
 been generated when running the generate command.
 
 Let's take a look at the `manifest.yml`:
@@ -150,7 +150,7 @@ Installing archive into local repository completed
   | ├─┬ templates
   | | └── readme.vm
   | └─┬ tests
-  |   └── AddReadme.rt
+  |   └── AddReadmeTest.ts
   ├── .atomist.yml
   ├── .gitignore
   ├─┬ META-INF/maven/atomist-rugs/my-rug-project
@@ -219,7 +219,7 @@ Publishing archive into remote repository completed
   | ├─┬ templates
   | | └── readme.vm
   | └─┬ tests
-  |   └── AddReadme.rt
+  |   └── AddReadmeTest.ts
   ├── .atomist.yml
   ├── .gitignore
   ├─┬ META-INF/maven/atomist-rugs/my-rug-project

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -95,6 +95,7 @@ pages:
         - CLI:
             - Overview: user-guide/interfaces/cli/index.md
             - Installation: user-guide/interfaces/cli/install.md
+            - Basics: user-guide/interfaces/cli/basics.md
             - Using Rugs: user-guide/interfaces/cli/using-rugs.md
             - Developing Rugs: user-guide/interfaces/cli/developing-rugs.md
 - Reference Documentation:


### PR DESCRIPTION
Use the auto-generated Rug CLI docs for the CLI reference material.
Move the old CLI reference content under its user guide, cleaning up
and reorganizing as appropriate along the way.  Fix admonitions.

The Developing Rugs guide still needs to be updated for TypeScript.