### PR TITLE
mention .atomist/ignore in the big generator page

### DIFF
--- a/docs/user-guide/rug/generators.md
+++ b/docs/user-guide/rug/generators.md
@@ -7,7 +7,8 @@ to create new projects.  The transformations are encoded in the Rug
 generator script located under the project's `.atomist` directory.
 Using these components, a generator does the followings:
 
-1.  Copy the content of its host project, `.atomist` directory
+1.  Copy the content of its host project, `.atomist` directory 
+    (and anything listed in `.atomist/ignore`)
     excluded, into the new target directory
 2.  Runs the generator's `populate` function against the contents of
     target directory


### PR DESCRIPTION
This may not be the best place to mention it?

I'll be happy with it later in the page if you'd rather keep this part clean.
As long as I can search this page for "ignore" and find this info, it's cool