### PR TITLE
Add repo linking instructions, fix non-links

### DIFF
--- a/docs/developer/commands.md
+++ b/docs/developer/commands.md
@@ -19,10 +19,10 @@ In this guide you'll create MyCommandHandler, which responds to "do my thing".
 
 ## Command handler
 
-Command handlers are classes with a `handle` method
- and some decorators that supply metadata.
-Store them anywhere in the `src` directory;
-your automation client discovers them on startup. (Or [specify them yourself](client.md#client-configuration).)
+Command handlers are classes with a `handle` method and some
+decorators that supply metadata.  Store them anywhere in the `src`
+directory; your automation client discovers them on startup
+(or [specify them yourself](client.md#client-configuration)).
 
 You can add a class to any file,
 or make a new TypeScript file anywhere in the `src` directory,
@@ -32,13 +32,16 @@ Start by copying the content of
 [the HelloWorld sample](https://github.com/atomist/automation-client-samples-ts/blob/master/src/commands/simple/HelloWorld.ts)
 into a new file to start with.
 
-A command handler class implements `HandleCommand`,
-with a `handle` method, and is decorated with `@CommandHandler`.
- It can also contain [parameter specifications](#parameters)
-  to gather additional information.
+A command handler class implements `HandleCommand`, with a `handle`
+method, and is decorated with `@CommandHandler`.  It can also
+contain [parameter specifications](#parameters) to gather additional
+information.
 
-The `@CommandHandler(description: string, intent: string)` decorator on the class adds the top-level metadata that Atomist needs to run your command handler.
-The `intent` parameter is important: it's the phrase people type in Slack to trigger this handler. Your `description` will show up in help messages.
+The `@CommandHandler(description: string, intent: string)` decorator
+on the class adds the top-level metadata that Atomist needs to run
+your command handler.  The `intent` parameter is important: it's the
+phrase people type in Slack to trigger this handler. Your
+`description` will show up in help messages.
 
 Implement your automation in the `handle` method.
 
@@ -64,7 +67,8 @@ export class MyCommandHandler implements HandleCommand {
 
 ### Handler arguments
 
-The `handle` method receives a `HandlerContext` [LINK to API docs if we have those?)]. It contains the following useful members:
+The `handle` method receives a [`HandlerContext`][handler-context]. It
+contains the following useful members:
 
 -   `messageClient: MessageClient` lets you send Slack messages from
     the Atomist bot.  You can send messages to
@@ -78,6 +82,8 @@ The `handle` method receives a `HandlerContext` [LINK to API docs if we have tho
 
 When you need more information, define [parameters](#parameters)
 in your command handler.
+
+[handler-context]: https://atomist.github.io/automation-client-ts/interfaces/_handlercontext_.handlercontext.html (Reference Documentation - Handler Context)
 
 ### Handler return
 
@@ -176,11 +182,11 @@ public animal: string = "armadillo";
 
 You can define:
 
-| field | meaning |
+| Field | Meaning |
 | ----- | ------- |
 | pattern | If you want to validate values, pass a `RegExp`. It must start with `^` and end with `$` so that it covers the whole value. Default: `/^[\S\s]*$/` for "anything" |
 | required | set this to `false` if the parameter is optional. If you supply a default value for the field, we'll automatically set required to `false`! |
-| description | the Slack or Dashboard user will see this when they're prompted for the parameter. [TODO | is that true about the dashboard?] |
+| description | the Slack or Atomist dashboard user will see this when they're prompted for the parameter. |
 | displayName | defaults to the name of the field you're decorating |
 | validInput | if you supplied a pattern, you may also want to describe in words what input is valid. |
 | displayable | If `false`, hide this parameter from the user before when prompting them to submit. For instance, sometimes buttons include cryptic internal identifiers. |
@@ -212,14 +218,17 @@ The available Mapped Parameters are:
 | MappedParameters.SlackChannelName | The name of the channel where the command was invoked. |
 | MappedParameters.SlackChannel | The ID of the channel where the command was invoked. For instance: C3NGYQF6Y |
 | MappedParameters.SlackTeam | The ID of your Slack team. For instance: T6MFSPUDL |
-| MappedParameters.GitHubRepository | If the command was invoked in a channel linked[LINK] to exactly one repository, this is the name of it. Otherwise, prompt for one of the repository names in your team. |
-| MappedParameters.GitHubOwner | If your team has one linked organization[LINK], this is it. If the command was invoked in a channel linked[LINK] to exactly one repository, this is the owner of that repository. Otherwise, prompt for one of the organizations linked to your team. |
+| MappedParameters.GitHubRepository | If the command was invoked in a [channel linked to exactly one repository][repo-link], this is the name of it. Otherwise, prompt for one of the repository names in your team. |
+| MappedParameters.GitHubOwner | If your team has one [linked organization][github-org], this is it. If the command was invoked in a [channel linked to exactly one repository][repo-link], this is the owner of that repository. Otherwise, prompt for one of the organizations linked to your team. |
 | MappedParameters.GitHubUrl | This is https://github.com unless you're on GitHub Enterprise. |
 | MappedParameters.GitHubApiUrl | This is https://api.github.com unless you're on GitHub Enterprise. |
 | MappedParameters.GitHubDefaultRepositoryVisibility | our best guess for whether you prefer to create new repositories as "public" or "private". |
 
 !!! note
     Mapped Parameters are available in Command Handlers but _not_ Event Handlers.
+
+[repo-link]: ../user/index.md#linking-slack-github (Link GitHub Repository to Slack Channel)
+[github-org]: ../user/index.md#organization-webhooks (Link GitHub Organization to Atomist)
 
 ## Examples
 
@@ -378,8 +387,9 @@ If you can't tell, consider changing the name of your automation client
 (in package.json) to something you'll recognize.
 
 If your automation client is listed but your automation is not,
-perhaps it is not included in `atomist.config.ts`.
-See command discovery [LINK].
+perhaps it is not included in [`atomist.config.ts`][client-config].
+
+[client-config]: client.md#client-configuration
 
 ### Command was invoked unsuccessfully
 

--- a/docs/developer/graphql.md
+++ b/docs/developer/graphql.md
@@ -162,9 +162,11 @@ mutations available to handlers in automation clients.
 | `createSlackChannel` | Create a new public channel in Slack |
 | `addBotToSlackChannel` | Invite the Atomist bot user into the given channel |
 | `inviteUserToSlackChannel` | Invite any user into the given channel |
-| `linkSlackChannelToRepo` | Link a repository to a Slack channel |
+| `linkSlackChannelToRepo` | [Link a GitHub repository to a Slack channel][repo-link] |
 | `setTeamPreference` | Set preference data on the team entity |
 | `setUserPreference` | Set preference data on the user entity |
+
+[repo-link]: ../user/index.md#linking-slack-github (Link GitHub Repository to Slack Channel)
 
 Like queries, mutations can be loaded from files and executed with the
 `GraphClient`. Here is an example showing how to create a new channel in Slack.

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -109,16 +109,19 @@ git clone git@github.com:atomist-blogs/event-handler.git event-handler \
     && npm start
 ```
 
-Next, trigger this event handler by making a commit in a repository
-that is linked to a Slack channel. The commit message should include
-the word "Crushed" followed by a reference to an issue in the form
-`#N`, replacing `N` with the number of the issue.
+Next, trigger this event handler by making a commit in
+a [repository that is linked to a Slack channel][repo-link]. The
+commit message should include the word "Crushed" followed by a
+reference to an issue in the form `#N`, replacing `N` with the number
+of the issue.
 
 Push that commit and the bot sends a message to the linked channel
 letting everyone know you crushed it!
 
 For more detailed information about customizing event handling, see the full documentation
 for [events][event].
+
+[repo-link]: user/index.md#linking-slack-github (Link GitHub Repository to Slack Channel)
 
 ## Dive in
 

--- a/docs/user/index.md
+++ b/docs/user/index.md
@@ -16,7 +16,7 @@
 This is a step by step guide to setting up Atomist's built-in
 automations to see and control your development flow
 from [Slack][slack].  To write your own automations, see the
-full [Developer Guide][dev].
+full [developer guide][dev].
 
 [slack]: https://slack.com/ (Slack)
 [dev]: ../developer/index.md (Atomist Developer Guide)
@@ -25,7 +25,8 @@ full [Developer Guide][dev].
 
 ### Enroll Slack bot
 
-Click the "Add to Slack" button below to invite the Atomist Bot into your Slack team.
+Click the "Add to Slack" button below to invite the Atomist bot into
+your Slack team.
 
 <div style="text-align:center;">
   <a href="https://atm.st/2wiDlUe" onclick="trackOutboundLink('https://atm.st/2wiDlUe'); return false;" target="_blank">
@@ -43,32 +44,33 @@ an "Approved Apps" setting to control this.
 ![Slack Approved Apps](img/ApprovedApps.png)
 
 If your team requires approval for new apps and you're not a Slack
-admin, Slack helps you request approval from a Slack admin 
-to install the Atomist application.
+administrator, Slack helps you request approval from your Slack team's
+administrators to install the Atomist application.
 
 Currently the authorization process asks you to authorize two things:
 
 1.  The Atomist app adds a bot user named "@atomist" to your team.
-    Your team can `\invite` the Atomist bot to channels in order to
-    access functionality that you deployed using the Atomist
-    platform.  Bot users cannot create channels, cannot
-    join channels unless they are invited by a non-bot channel member,
-    and cannot see messages in channels where they are not a
+    Your team can `\invite` the Atomist bot to channels to access the
+    full functionality of Atomist.  Bot users cannot create channels,
+    cannot join channels unless they are invited by a non-bot channel
+    member, and cannot see messages in channels where they are not a
     member.
-2.  Atomist requests a scope called "Modify public channels".
-    This scope allows Atomist to help you setup channels.  For example, 
-    when you create a project in a new GitHub repo, Atomist can create 
-    a Slack channel to go with it.
+2.  Atomist requests a scope called "Modify public channels".  This
+    scope allows Atomist to help you setup channels.  For example,
+    when you [create a project][create-project] in a new GitHub
+    repository, Atomist can create a Slack channel to go with it.
 
 !!! Note
-    The Atomist app
-    creates new channels on behalf of the user who first authorizes Atomist.
+    The Atomist app creates new channels on behalf of the user who
+    first authorizes Atomist.
+
+[create-project]: ../developer/create.md (Create Project with Atomist)
 
 ### Slack team ID
 
 Some operations, like [connecting your CI with Atomist][ci], need you to pass
 in your Slack team ID. To get your Slack team ID, send `team` to the Atomist
-bot. 
+bot.
 
 ```
 you> /invite @atomist
@@ -87,8 +89,8 @@ doesn't come to this!
 
 The [App Manage page][slack-app-settings] has a "Remove App" button at
 the bottom of the page.  Please [let us know][support-email] if
-there's anything we can do to clarify how the bot works with your
-team's channels.
+there's anything we can do to clarify how the bot works within your
+Slack team.
 
 [slack-app-settings]: https://slack.com/apps/A0HM83NCC-atomist?page=1
 [support-email]: mailto:support@atomist.com
@@ -108,47 +110,46 @@ Atomist helps you work with GitHub in two ways:
 
 ### GitHub user authorization
 
-When the Atomist bot first arrives in a team, it will send a Direct Message
-to the authorizing user, requesting that they authorize Atomist
-to access GitHub on their behalf.
+When the Atomist bot first arrives in a team, it will send a direct
+message to the authorizing user, requesting that they authorize
+Atomist to access GitHub on their behalf.
 
 ![GitHub Authorization](img/github-auth.png)
 
-This same dialog will be shown to users anytime Atomist detects
-that an automation needs to access GitHub as that user.  Every user on the
+This same dialog will be shown to users anytime Atomist detects that
+an automation needs to access GitHub as that user.  Every user on the
 team must individually opt in.  Atomist will display this option each
-time an un-authorized user runs a Command
-that requires a GitHub authorization.
-Users can ask for their current GitHub authorization status by running:
+time an un-authorized user runs a command that requires a GitHub
+authorization.  Users can ask for their current GitHub authorization
+status by running:
 
 ```
 you> @atomist github
 ```
 
-Atomist will send a direct message to this user with their current Authorization
-status.
+Atomist will send a direct message to this user with their current
+GitHub authorization status.
 
 ### Organization webhooks
 
-GitHub organization members that have the [owner role][owners], are allowed
-to configure Organization-wide webhooks.  This is convenient
-because it only has to be configured once;
-however, you will require a user who has the `owner` role in
-your GitHub organization.
+GitHub organization members that have the [owner role][owners], are
+allowed to configure organization webhooks.  This is convenient
+because it only has to be configured once; however, you will require a
+user who has the `Owner` role in your GitHub organization.
 
 ```
 you> @atomist enroll org
 ```
 
-When you choose to enroll a GitHub Organization, you will most likely be
-prompted to authorize a new scope (Atomist only asks for new scopes when
-explicitly required).  The `admin:org_hook` is required when enrolling a new
-GitHub organization.
+When you choose to enroll a GitHub organization, you will most likely
+be prompted to authorize a new scope (Atomist only asks for new scopes
+when explicitly required).  The *admin:org_hook* is required when
+enrolling a new GitHub organization.
 
 ![GitHub Authorize Organization Webhook](img/authorize-org-hook.png)
 
-Since you might be a member of many GitHub organizations, Atomist may ask you to
-choose which organization you are enrolling.
+If you are a member of more than one GitHub organization, Atomist will
+ask you to choose which organization to enroll.
 
 ![Choose GitHub Organization](img/choose-org.png)
 
@@ -160,8 +161,9 @@ Finally, you will be presented with a button to configure the organization webho
 
 ### Repository webhooks
 
-If your team does not use a GitHub organization account, then you can choose to
-configure webhooks on repositories owned by a user account.
+If your team does not use a GitHub organization account, you can
+choose to configure webhooks on individual repositories owned by your
+user account.
 
 ```
 you> @atomist install webhook
@@ -174,6 +176,24 @@ asks you to select the repository to receive the new webhook.
 <div style="text-align:center;">
   <img alt="Choose GitHub Repository" height="137" width="528" src="img/choose-repo.png" />
 </div>
+
+## Linking Slack & GitHub
+
+Now that you have Slack and GitHub connected with Atomist, you should
+"link" GitHub repositories with Slack channels so you can see and
+control your project's activity from Slack.  All you need to do is
+invite the Atomist bot to a Slack channel and then send it `repo`.
+
+```
+/invite @atomist
+@atomist repo
+```
+
+The bot will open a thread and ask you what GitHub repository you want
+to link to the channel.  If you added an organization webhook, you can
+link any repository in your GitHub organization.  If you added
+webhooks to individual repositories, you will only be able to link
+those repositories.
 
 ## Continuous integration
 


### PR DESCRIPTION
Add instructions for linking channels and repos in the user guide.
Add links to the repo linking instructions throughout the docs.

Fix non-links in commands doc.

In user guide, fix too many capital letters, minor wordsmithing in
user guide, and puts GitHub scopes in italics, as GitHub does and we
do we elsewhere in the docs.

Closes #202