### PR TITLE
Replace Google UA with Google Tag Manager

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,7 +1,7 @@
 site_name: The Atomist Documentation
 site_description: Documentation for the Atomist Development Automation Platform
 site_author: The Atomist Team
-copyright: '&copy; 2017 Atomist, Inc.'
+copyright: '&copy; 2018 Atomist, Inc.'
 extra:
   main_site_url: https://www.atomist.com/
 theme:
@@ -14,6 +14,7 @@ theme:
   font:
     text: Roboto
     code: Roboto Mono
+  custom_dir: 'theme'
 extra:
   social:
     - type: medium
@@ -29,9 +30,12 @@ extra_css:
 extra_javascript:
   - js/intercom.js
   - js/mixpanel.js
-google_analytics:
-  - UA-74966852-1
-  - auto
+#google_analytics:
+#  - UA-74966852-1
+#  - auto
+#google:
+#  tag_manager:
+#    container_id: GTM-MZ8NMFS
 markdown_extensions:
   - markdown_include.include:
       base_path: "docs/common"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,12 +30,6 @@ extra_css:
 extra_javascript:
   - js/intercom.js
   - js/mixpanel.js
-#google_analytics:
-#  - UA-74966852-1
-#  - auto
-#google:
-#  tag_manager:
-#    container_id: GTM-MZ8NMFS
 markdown_extensions:
   - markdown_include.include:
       base_path: "docs/common"

--- a/theme/main.html
+++ b/theme/main.html
@@ -10,7 +10,7 @@
     <!-- End Google Tag Manager -->
 {% endblock %}
 
-<!-- Application header -->
+<!-- Hack application header to add Google Tag Manager support -->
 {% block header %}
 <!-- Google Tag Manager (noscript) -->
     <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MZ8NMFS"

--- a/theme/main.html
+++ b/theme/main.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+
+{% block extrahead %}
+<!-- Google Tag Manager -->
+<script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+    'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+    })(window,document,'script','dataLayer','GTM-MZ8NMFS');</script>
+    <!-- End Google Tag Manager -->
+{% endblock %}
+
+<!-- Application header -->
+{% block header %}
+<!-- Google Tag Manager (noscript) -->
+    <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-MZ8NMFS"
+    height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+    <!-- End Google Tag Manager (noscript) -->
+  {% include "partials/header.html" %}
+{% endblock %}


### PR DESCRIPTION
Swapped out Google Analytics code with Google Tag Manager code via the theme customization feature of Mkdocs Material theme.

This is so we can use Google Tag Manager for analytics across Atomist properties instead of manual configuration of each property separately.